### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,11 @@ logaware
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/logaware
 
-.. |supported-versions| image:: https://pypip.in/py_versions/logaware/badge.svg?style=flat
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/logaware.svg?style=flat
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/logaware
 
-.. |supported-implementations| image:: https://pypip.in/implementation/logaware/badge.svg?style=flat
+.. |supported-implementations| image:: https://img.shields.io/pypi/implementation/logaware.svg?style=flat
     :alt: Supported implementations
     :target: https://pypi.python.org/pypi/logaware
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def _read(*names, **kwargs):
 
 setup(
     name='logaware',
-    version='0.1.0',
+    version='0.2.0',
     license='BSD',
     description='Python Logger that knows where it\'s coming from',
     long_description='%s\n%s' % (

--- a/src/logaware/logger.py
+++ b/src/logaware/logger.py
@@ -68,6 +68,12 @@ class LoggerMetaClass(type):
     """
     def __new__(mcs, name, bases, attrs):
         levels = {}
+        # Inherit base class levels
+        for base in bases:
+            base_levels = getattr(base, '_log_levels', None)
+            if base_levels:
+                levels.update(base_levels)
+
         for key, val in attrs.items():
             if isinstance(val, LogLevel):
                 levels[val.level] = val

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from io import BytesIO, TextIOWrapper, StringIO
+from io import BytesIO, TextIOWrapper
 
 
 @pytest.fixture
@@ -37,6 +37,7 @@ def lastlog_factory(request):
             raw_stream.seek(0)
             data = raw_stream.read().strip()
             raw_stream.truncate(0)
+            raw_stream.seek(0)
             return data
 
         return log_pop

--- a/tests/example/loggers.py
+++ b/tests/example/loggers.py
@@ -1,0 +1,63 @@
+import threading
+from contextlib import contextmanager
+
+from logaware.logger import AwareLogger, LogLevel, log_method_factory
+from logaware.metalogger import MetaAwareLogger, LogMetaManager, LogMeta
+
+
+class CustomLogger(AwareLogger):
+    """
+    Logger with additional levels for auditing and debugging.
+    """
+    # Log for changes that must be audited
+    AUDIT = LogLevel(99, 'AUDIT')
+    audit = log_method_factory('audit', AUDIT)
+
+    # Log error messages with traceback
+    FAIL = LogLevel(100, 'FAIL')
+    fail = log_method_factory('fail', FAIL, traceback=True)
+
+
+# Shared instance for custom logger
+# Import this logger into any module and use it's logging methods
+custom_log = CustomLogger()
+
+# Shared instance for standard logger
+# Import this logger into any module and use it's logging methods
+log = AwareLogger()
+
+# Use a thread local to maintain meta data for each thread. This
+# works for basic threaded Python applications. For more robust
+# handling for threads and co-routines, see Context Locals
+# (http://werkzeug.pocoo.org/docs/0.11/local/). If using
+# a framework like Flask, consider using ``flask.g``
+# (http://flask.pocoo.org/docs/0.11/api/#flask.g)
+_meta_local = threading.local()
+
+
+@contextmanager
+def log_meta_context(**kwargs):
+    """
+    Set log meta data within a context for current thread. Can be nested.
+
+    Each nested context will inherit the meta from the parent context.
+    """
+    if not hasattr(_meta_local, 'meta'):
+        _meta_local.meta = []
+
+    if len(_meta_local.meta):
+        # Seems to be a nested context. Include meta from the parent
+        # context
+        d = _meta_local.meta[-1].to_dict()
+        d.update(kwargs)
+        kwargs = d
+
+    _meta_local.meta.append(LogMeta(**kwargs))
+
+    yield _meta_local.meta[-1]
+    # Remove the current meta from the stack after the context exits
+    _meta_local.meta.pop()
+
+# Import this logger into any module and use it's logging methods.
+# It will get it's meta data from a ``log_meta_context``.
+meta_log = MetaAwareLogger(getter=lambda: _meta_local.meta[-1] if getattr(_meta_local, 'meta', None) else '{}')

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,89 @@
+from .example.loggers import log, custom_log, log_meta_context, meta_log
+
+
+def test_example_basic_logger(lastlog_factory):
+    """
+    Verify basic shared logger is context aware.
+    """
+    lastlog = lastlog_factory('tests', format=u'%(name)s:%(levelname)s:%(message)s')
+
+    log.info('{user} logged in.', user='admin')
+
+    log_message = lastlog()
+    assert log_message.startswith('tests.test_examples:'), \
+        'Expect module to be test\'s module, not loggers module.'
+    assert log_message == 'tests.test_examples:INFO:admin logged in.'
+
+
+def test_example_custom_logger(lastlog_factory):
+    """
+    Verify custom logger has custom logging level methods.
+    """
+    lastlog = lastlog_factory('tests', format=u'%(name)s:%(levelname)s:%(message)s')
+
+    custom_log.info('{user} logged in.', user='admin')
+
+    expected_log = 'tests.test_examples:INFO:admin logged in.'
+    assert lastlog() == expected_log
+
+    custom_log.audit(
+        '{user} changed {key} from {old_value} to {new_value}',
+        user='admin',
+        key='security_enabled',
+        old_value=True,
+        new_value=False
+    )
+
+    expected_log = 'tests.test_examples:AUDIT:admin changed security_enabled from True to False'
+    assert lastlog() == expected_log
+
+    try:
+        # Raise some exception so we can test exc_info
+        raise ValueError('Test exc_info')
+    except ValueError:
+        custom_log.fail('{user} failed.', user='admin')
+
+    expected_log = 'tests.test_examples:FAIL:admin failed.'
+
+    lines = lastlog().split(b'\n')
+    assert lines[0] == expected_log, \
+        'First log line should be expected log message'
+
+    # Must be exc_info
+    assert len(lines) > 1
+    assert lines[1].startswith(b'Traceback'), \
+        'Expected traceback info in log message'
+
+
+def test_example_meta_logger(lastlog_factory):
+    """
+    Verify example meta logger can get meta info from thread context.
+    """
+    lastlog = lastlog_factory('tests', format=u'%(name)s:%(levelname)s:%(message)s:%(meta)s')
+
+    # Not in meta context so no meta data.
+    meta_log.error('User not found.')
+    assert lastlog() == 'tests.test_examples:ERROR:User not found.:{}'
+
+    with log_meta_context(user='admin'):
+        # Log message will have ``user`` from meta context
+        meta_log.info('User logged in.')
+
+        assert lastlog() == 'tests.test_examples:INFO:User logged in.:{"user":"admin"}'
+
+        with log_meta_context(name='Bob'):
+            # Log message will have ``user`` from parent meta context
+            # and ``name`` from current context.
+            meta_log.info('User updated info.')
+
+            assert lastlog() == 'tests.test_examples:INFO:User updated info.:{"name":"Bob", "user":"admin"}'
+
+        # Log message will have only have meta from original context
+        meta_log.info('User says hi.')
+
+        assert lastlog() == 'tests.test_examples:INFO:User says hi.:{"user":"admin"}'
+
+    # {user} will be None because the meta context has exited
+    meta_log.info('User logged out.')
+
+    assert lastlog() == 'tests.test_examples:INFO:User logged out.:{}'

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -265,6 +265,9 @@ def test_custom_level(lastlog):
 
     log = CustomLogger()
 
+    # Verify base levels are inherited
+    assert log.get_level_name(20) == 'INFO'
+    # Verify custom levels
     assert log.get_level_name(42) == 'BLERG'
 
     log.blerg('Blergit!')

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     pytest-capturelog
     pytest-cover
 commands =
-    {posargs:py.test --cov --cov-report=term-missing -vv}
+    py.test {posargs:--cov --cov-report=term-missing -vv}
 usedevelop = true
 
 [testenv:spell]


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20logaware))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `logaware`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.