### PR TITLE
Add `isEnabledFor` method to AwareLogger.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
       env: TOXENV=2.7
     - python: 2.7
       env: TOXENV=check
-    - python: 3.3
-      env: TOXENV=3.3
     - python: 3.4
       env: TOXENV=3.4
     - python: 3.5

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+
+0.2.1
+-----
+
+- Implemented `AwareLogger.isEnabledFor` to make more compatible as a drop-in
+  replacement for native loggers.
+
+
 0.1.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def _read(*names, **kwargs):
 
 setup(
     name='logaware',
-    version='0.2.0',
+    version='0.2.1',
     license='BSD',
     description='Python Logger that knows where it\'s coming from',
     long_description='%s\n%s' % (

--- a/src/logaware/logger.py
+++ b/src/logaware/logger.py
@@ -96,6 +96,8 @@ class AwareLogger(with_metaclass(LoggerMetaClass)):
     example, if this was being called in ``logaware.logger``, the log
     message would include ``logaware.logger`` as the logger name::
 
+        >>> import logging
+        >>> logging.getLogger().setLevel(logging.DEBUG)
         >>> log = AwareLogger()
         >>> log.info('Test message').module
         '...logaware.logger'
@@ -160,6 +162,23 @@ class AwareLogger(with_metaclass(LoggerMetaClass)):
             unicode: Name of logging level
         """
         return text_type(self._log_levels.get(level, (u'Level %s' % level)))
+
+    def isEnabledFor(self, level):
+        """
+        Is this logger enabled for level 'level'?
+
+        Note: Wrapper around native logger method.
+
+        Args:
+            level (int): Logging level
+
+        Returns:
+            boolean: Whether or not logging is enabled for `level`.
+        """
+        # _get_caller will only work if the callstack is exactly 3
+        module_name, filename, line_number, func_name = _get_caller()
+        logger = logging.getLogger(module_name)
+        return logger.isEnabledFor(level)
 
     def _log(self, level, message, kwargs):
         # _get_caller will only work if the callstack is exactly 3

--- a/src/logaware/logger.py
+++ b/src/logaware/logger.py
@@ -176,7 +176,7 @@ class AwareLogger(with_metaclass(LoggerMetaClass)):
             boolean: Whether or not logging is enabled for `level`.
         """
         # _get_caller will only work if the callstack is exactly 3
-        module_name, filename, line_number, func_name = _get_caller()
+        module_name, _, _, _ = _get_caller()
         logger = logging.getLogger(module_name)
         return logger.isEnabledFor(level)
 

--- a/src/logaware/metalogger.py
+++ b/src/logaware/metalogger.py
@@ -6,7 +6,7 @@ from .logger import AwareLogger
 
 try:
     from simplejson import json
-except:
+except ImportError:
     import json
 
 
@@ -94,6 +94,8 @@ class LogMetaManager(object):
 
     To add other information to the log output, use ``set_meta``::
 
+        >>> import logging
+        >>> logging.getLogger().setLevel(logging.DEBUG)
         >>> meta = LogMetaManager()
         >>> meta.set_meta(user='foo', nothing=None)
         <LogMeta {"user":"foo"}>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,9 @@ def lastlog_factory(request):
         stream = TextIOWrapper(raw_stream, encoding=encoding)
 
         logger = logging.getLogger(logger)
-        logger.setLevel(0)
+        logger.setLevel(1)
         handler = logging.StreamHandler(stream)
-        handler.setLevel(0)
+        handler.setLevel(logger.level)
         handler.setFormatter(logging.Formatter(format))
         logger.addHandler(handler)
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -307,3 +307,18 @@ def test_custom_level_with_traceback(lastlog):
         assert len(lines) > 1
         assert lines[1].startswith(b'Traceback'), \
             'Expected traceback info in log message'
+
+
+def test_logger_is_enabled_for():
+    """
+    Verify that an AwareLogger can be used like a native logger instance for
+    determining if logging is enabled for a specific log level.
+    """
+    logger = logging.getLogger()
+    previous_level = logger.level
+    logger.setLevel(999)
+    aware_logger = AwareLogger()
+    assert aware_logger.isEnabledFor(999)
+    assert not aware_logger.isEnabledFor(900)
+    assert aware_logger.isEnabledFor(1000)
+    logger.setLevel(previous_level)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 envlist =
     clean,
     check,
-    {2.7,3.3,3.4,3.5,pypy}
+    {2.7,3.4,3.5,pypy}
     report,
     docs
 
@@ -12,7 +12,6 @@ envlist =
 basepython =
     pypy: {env:TOXPYTHON:pypy}
     {2.7,docs,report,clean,check}: {env:TOXPYTHON:python2.7}
-    3.3: {env:TOXPYTHON:python3.3}
     3.4: {env:TOXPYTHON:python3.4}
     3.5: {env:TOXPYTHON:python3.5}
 setenv =
@@ -24,6 +23,7 @@ deps =
     pytest
     pytest-capturelog
     pytest-cover
+
 commands =
     py.test {posargs:--cov --cov-report=term-missing -vv}
 usedevelop = true


### PR DESCRIPTION
- Added `isEnabledFor` method so that logaware loggers are more compatible
  as drop-in replacements for native loggers.
- Added test to verify `isEnabledFor` is present and works like the native
  method.

Note: not all tests are passing, but the one I added does!